### PR TITLE
extend JsoupBrowser settings for more advanced crawling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea

--- a/modules/scraper/src/main/scala/com/marekkadek/scraper/jsoup/browser.scala
+++ b/modules/scraper/src/main/scala/com/marekkadek/scraper/jsoup/browser.scala
@@ -5,6 +5,7 @@ import com.marekkadek.scraper.proxy.ProxySettings
 import fs2.util._
 import org.jsoup._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 
@@ -12,8 +13,15 @@ sealed class JsoupBrowser[F[_]] private (val proxySettings: Option[ProxySettings
                                          connectionTimeout: Duration,
                                          userAgent: String,
                                          followRedirects: Boolean,
-                                         validateTLSCertificates: Boolean)(implicit FI: Effect[F])
+                                         validateTLSCertificates: Boolean,
+                                         referrer: Option[String],
+                                         cookiesProvider: Option[() => Map[String, String]],
+                                         cookiesConsumer: Option[Map[String, String] => Unit],
+                                         headersProvider: Option[() => Map[String, String]],
+                                         headersConsumer: Option[Map[String, String] => Unit]
+                                        )(implicit FI: Effect[F])
     extends Browser[F] {
+
   override def fromUrl(url: String): F[Document] =
     FI.delay {
       val con = Jsoup.connect(url)
@@ -23,10 +31,16 @@ sealed class JsoupBrowser[F[_]] private (val proxySettings: Option[ProxySettings
       con.validateTLSCertificates(validateTLSCertificates)
       con.ignoreHttpErrors(true) // do not throw exceptions in `execute`
       con.ignoreContentType(true)
+      cookiesProvider.foreach(c => con.cookies(c().asJava))
+      headersProvider.foreach(h => con.headers(h().asJava))
+      referrer.foreach(con.referrer)
       proxySettings.foreach(x => con.proxy(x.toProxy))
       con.timeout(connectionTimeout.toMillis.toInt)
 
       val r = con.execute()
+
+      cookiesConsumer.foreach(c => c(r.cookies().asScala.toMap[String, String]))
+      headersConsumer.foreach(h => h(r.headers().asScala.toMap[String, String]))
 
       JsoupDocument(r.parse)
     }
@@ -40,12 +54,22 @@ object JsoupBrowser {
                           connectionTimeout: Duration = 3.seconds,
                           userAgent: String = "Mozilla",
                           followRedirects: Boolean = true,
-                          validateTLSCertificates: Boolean = true): JsoupBrowser[F] =
+                          validateTLSCertificates: Boolean = true,
+                          referrer: Option[String] = Option.empty,
+                          cookiesProvider: Option[() => Map[String, String]] = Option.empty,
+                          cookiesConsumer: Option[Map[String, String] => Unit] = Option.empty,
+                          headersProvider: Option[() => Map[String, String]] = Option.empty,
+                          headersConsumer: Option[Map[String, String] => Unit] = Option.empty): JsoupBrowser[F] =
     new JsoupBrowser[F](proxySettings,
                         connectionTimeout,
                         userAgent,
                         followRedirects,
-                        validateTLSCertificates)
+                        validateTLSCertificates,
+                        referrer,
+                        cookiesProvider,
+                        cookiesConsumer,
+                        headersProvider,
+                        headersConsumer)
 
   def readInputStream[F[_]](is: java.io.InputStream, charset: java.nio.charset.Charset, baseUri: String)(
       implicit FI: Effect[F]): F[Document] = FI.delay {


### PR DESCRIPTION
Should allow to build a more advanced crawler with custom headers and cookies as well as consuming cookies and headers from `Respose`

Changes should not affect any old client code